### PR TITLE
ci: pin GitHub Actions runners to ubuntu-22.04

### DIFF
--- a/.github/workflows/bench_and_report.yml
+++ b/.github/workflows/bench_and_report.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   bench:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/lint_test.yml
+++ b/.github/workflows/lint_test.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   lint_and_unit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/sim_tests.yml
+++ b/.github/workflows/sim_tests.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   sim:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Standardize all workflows on ubuntu-22.04 for consistency.